### PR TITLE
Add Flask-SQLAlchemy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask
+Flask-SQLAlchemy
+SQLAlchemy


### PR DESCRIPTION
## Summary
- require `Flask-SQLAlchemy` (and `SQLAlchemy`) in `requirements.txt`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f4f1ec868832a94289406d86f5c25